### PR TITLE
Install rebar3 in the container for deps that need it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/in
 ENV MIX_HOME=/var/mix
 
 RUN mix local.hex --force && \
+    mix local.rebar --force && \
     mix archive.install --force github rrrene/bunt && \
     mix archive.install --force github rrrene/credo
 


### PR DESCRIPTION
## Summary
- Consumer projects with transitive deps that compile via rebar3 (e.g. `:yamerl` pulled in by `yaml_elixir`) were failing in this action with `** (Mix) Could not find "rebar3" to compile dependency :yamerl`.
- The consumer's `mix local.rebar --force` only installs rebar3 into the GitHub runner's `HOME` — not into this Docker action's container — so any `:rebar3`-built dep blew up when the entrypoint ran `mix deps.*` inside the container.
- Bakes rebar3 into the image alongside the existing `mix local.hex --force`, so `MIX_HOME=/var/mix` has both helpers ready before any deps work runs. Matches the existing pattern for hex.

## Test plan
- [x] `docker build` succeeds with the new `mix local.rebar --force` line.
- [ ] Re-run the failing Credo CI job in `tanda-tech/tanda_bot` against this branch (or a tag pointing at it) and confirm `:yamerl` compiles without the rebar3 error.
- [ ] Once merged, move the floating `v4` tag (and any major-version tag the README references) so downstream `@v4` consumers pick up the fix.