### PR TITLE
Install build-essential for native NIF compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-$
 
 FROM ${BUILDER_IMAGE}
 
-RUN apt-get update -y && apt-get install -y git wget \
+RUN apt-get update -y && apt-get install -y git wget build-essential \
     && apt-get clean && rm -f /var/lib/apt/lists/*_*
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin/ v0.21.0
 


### PR DESCRIPTION
## Summary
- Adds `build-essential` (make, gcc, g++, libc-dev) to the Dockerfile so deps with C NIFs — `bcrypt_elixir`, `fast_html`, `exqlite`, etc. — can compile inside the action container.
- Without it, downstream consumers (e.g. tanda_bot) hit `** (Mix) "make" not found in the path.` even after the v5 rebar3 fix.
- `erl_nif.h` is already shipped by the hexpm Elixir image at `/usr/local/lib/erlang/erts-16.1/include/erl_nif.h`, so no extra header packages needed.

## Verification
Built the image locally and ran `mix deps.compile` against a minimal project pinning both `:yamerl` (rebar3) and `:bcrypt_elixir` (elixir_make + cc). Output:

```
==> comeonin
Compiling 3 files (.ex)
Generated comeonin app
==> verify
===> Analyzing applications...
===> Compiling yamerl
==> elixir_make
Compiling 8 files (.ex)
Generated elixir_make app
==> bcrypt_elixir
mkdir -p "/work/_build/dev/lib/bcrypt_elixir/priv"
cc -g -O3 -Wall -Wno-format-truncation -I"/usr/local/lib/erlang/erts-16.1/include" -Ic_src -fPIC -shared  c_src/bcrypt_nif.c c_src/blowfish.c -o "/work/_build/dev/lib/bcrypt_elixir/priv/bcrypt_nif.so"
Compiling 3 files (.ex)
Generated bcrypt_elixir app
```

`which make gcc g++` inside the image returns `/usr/bin/make`, `/usr/bin/gcc`, `/usr/bin/g++`.

## Follow-up
Once merged, tag `v6` so downstream can pin.

## Test plan
- [ ] Merge to master
- [ ] Tag v6 at the merge commit
- [ ] Re-run a downstream credo workflow to confirm